### PR TITLE
Fixes #47 addSystem to world

### DIFF
--- a/packages/ecs/src/world.ts
+++ b/packages/ecs/src/world.ts
@@ -11,6 +11,7 @@ type QueryMethod = <S extends Selector>(
 
 export type World<T = any> = {
   tick(data: T): void
+  addSystem(system: System<T>): void
   create(components: ReadonlyArray<Component>, tags?: number): number
   insert(entity: number, ...components: ReadonlyArray<Component>): void
   destroy(entity: number): void
@@ -98,6 +99,10 @@ export const createWorld = <T>(systems: System<T>[]): World<T> => {
     }
   }
 
+  function addSystem(system: System<T>) {
+    systems.push(system);
+  }
+
   function create(components: ReadonlyArray<Component>, tags?: number) {
     const entity = nextEntity++
     const op = opPool.retain() as CreateOp
@@ -152,6 +157,7 @@ export const createWorld = <T>(systems: System<T>[]): World<T> => {
     insert,
     destroy,
     tick,
+    addSystem,
     created,
     destroyed,
     storage,


### PR DESCRIPTION
This feature will allow a user to add a system to an already created
world via the `addSystem` function which consumes a system and adds it
to the list of systems that the world will execute on each tick.

Some other things to potentially add (in this PR)
- a `getSystem` function that returns a list of all the systems added for testing purposes - since at the moment there isn't an easy way to tell if a system was actually added.
- some tests for this, but this is somewhat dependent on the previous item
- an `addSystems(systems: System<T>[])` that will bulk add systems. My argument being that an `Arrays.concat` will be faster for bulk adding as opposed to a loop that calls `addSystem`. But on the flip-side I don't think bulk adding systems is that common, thoughts?

I'm not really sure if any those make sense though from a user perspective so it's up to you @3mcd 