### PR TITLE
Closese #47 update mocks to match type definition

### DIFF
--- a/packages/ecs/src/__mocks__/world.ts
+++ b/packages/ecs/src/__mocks__/world.ts
@@ -6,6 +6,7 @@ export const createWorld = jest.fn(
     let e = 0
     return {
       insert: jest.fn(),
+      addSystem: jest.fn(),
       create: jest.fn(() => e++),
       destroy: jest.fn(),
       addTag: jest.fn(),

--- a/packages/ecs/src/world.ts
+++ b/packages/ecs/src/world.ts
@@ -11,6 +11,7 @@ type QueryMethod = <S extends Selector>(
 
 export type World<T = any> = {
   tick(data: T): void
+  addSystem(system: System<T>): void
   create(components: ReadonlyArray<Component>, tags?: number): number
   insert(entity: number, ...components: ReadonlyArray<Component>): void
   destroy(entity: number): void
@@ -98,6 +99,10 @@ export const createWorld = <T>(systems: System<T>[]): World<T> => {
     }
   }
 
+  function addSystem(system: System<T>) {
+    systems.push(system);
+  }
+
   function create(components: ReadonlyArray<Component>, tags?: number) {
     const entity = nextEntity++
     const op = opPool.retain() as CreateOp
@@ -152,6 +157,7 @@ export const createWorld = <T>(systems: System<T>[]): World<T> => {
     insert,
     destroy,
     tick,
+    addSystem,
     created,
     destroyed,
     storage,


### PR DESCRIPTION
In my previous PR I had failed to update the mocks in `__mocks__`,
specifically for the world object. Since I updated its type definition
the tests were failing because I did not update the mock to match the
type definition.