### PR TITLE
WIP: Partial #49 Implement the topic logic

### DIFF
--- a/packages/ecs/src/topic.spec.ts
+++ b/packages/ecs/src/topic.spec.ts
@@ -22,21 +22,3 @@ describe("createTopic", () => {
     }
   })
 })
-
-/* describe("createStorage", () => {
-  it("creates a new archetype for each unique combination of components", () => {
-    const storage = createStorage()
-
-    storage.create(1, [{ _t: 0, _v: 0 }])
-    storage.create(2, [{ _t: 1, _v: 0 }])
-    storage.create(3, [
-      { _t: 0, _v: 0 },
-      { _t: 1, _v: 0 },
-    ])
-
-    expect(createArchetype).toHaveBeenNthCalledWith(1, [0])
-    expect(createArchetype).toHaveBeenNthCalledWith(2, [1])
-    expect(createArchetype).toHaveBeenNthCalledWith(3, [0, 1])
-  })
- 
-})*/

--- a/packages/ecs/src/topic.spec.ts
+++ b/packages/ecs/src/topic.spec.ts
@@ -1,0 +1,42 @@
+import { Topic, createTopic } from "./topic"
+
+describe("createTopic", () => {
+  it("creates a new topic with the given name", () => {
+    type TestType = {
+      mass: Number
+    }
+    const topic = createTopic<TestType>("testTopic");
+    expect(topic.name).toBe("testTopic");
+  })
+
+  it("adds events to it's list of events", () => {
+    type TestType = {
+      mass: Number
+    }
+    const topic: Topic<string, TestType> = createTopic<TestType>("testTopic");
+    topic.pushEvent({ mass: 17 });
+
+    for (const event of topic) {
+      console.log(event);
+      expect(event).toEqual({ mass: 17 });
+    }
+  })
+})
+
+/* describe("createStorage", () => {
+  it("creates a new archetype for each unique combination of components", () => {
+    const storage = createStorage()
+
+    storage.create(1, [{ _t: 0, _v: 0 }])
+    storage.create(2, [{ _t: 1, _v: 0 }])
+    storage.create(3, [
+      { _t: 0, _v: 0 },
+      { _t: 1, _v: 0 },
+    ])
+
+    expect(createArchetype).toHaveBeenNthCalledWith(1, [0])
+    expect(createArchetype).toHaveBeenNthCalledWith(2, [1])
+    expect(createArchetype).toHaveBeenNthCalledWith(3, [0, 1])
+  })
+ 
+})*/

--- a/packages/ecs/src/topic.spec.ts
+++ b/packages/ecs/src/topic.spec.ts
@@ -17,7 +17,6 @@ describe("createTopic", () => {
     topic.pushEvent({ mass: 17 });
 
     for (const event of topic) {
-      console.log(event);
       expect(event).toEqual({ mass: 17 });
     }
   })

--- a/packages/ecs/src/topic.ts
+++ b/packages/ecs/src/topic.ts
@@ -1,0 +1,52 @@
+export type Topic<T extends string = string, D = any> = {
+  /**
+   * A property for the name of the topic
+   */
+  name: string
+
+  /**
+   * Provides iterator syntax to the consumers of a topic. This will loop
+   * through all of the events with the type specified in the second type 
+   * parameter. 
+   */
+  [Symbol.iterator](): IterableIterator<D>;
+
+  /**
+   * Pushes an event to the topic so that it can be consumed by downstream 
+   * systems.
+   */
+  pushEvent(event: D): void
+
+  /**
+   * Utility method that cleans the event list in the topic such that at the 
+   * end of the tick (or after all the systems have consumed whatever events
+   * they are interested in we can flush out events that have already been 
+   * consumed.)
+   */
+  flush(): void
+}
+
+/**
+ * The utility method used to create a topic, consumes a type parameter 
+ * and a name and returns an object that conforms to the topic type
+ */
+export const createTopic = <E>(name: string): Topic<string, E> => {
+ 
+  let events: E[] = [];
+
+  const pushEvent = (event: E) => {
+    events.push(event)
+  }
+
+  const flush = () => {
+    events = [];
+  }
+
+
+  return {
+    name,
+    [Symbol.iterator]: events.values,
+    pushEvent,
+    flush
+  }
+}

--- a/packages/ecs/src/topic.ts
+++ b/packages/ecs/src/topic.ts
@@ -1,8 +1,10 @@
+import { mutableEmpty } from "./util/array"
+
 export type Topic<T extends string = string, D = any> = {
   /**
    * A property for the name of the topic
    */
-  name: string
+  readonly name: T
 
   /**
    * Provides iterator syntax to the consumers of a topic. This will loop
@@ -32,14 +34,14 @@ export type Topic<T extends string = string, D = any> = {
  */
 export const createTopic = <E>(name: string): Topic<string, E> => {
  
-  let events: E[] = [];
+  const events: E[] = [];
 
   const pushEvent = (event: E) => {
     events.push(event)
   }
 
   const flush = () => {
-    events = [];
+    mutableEmpty(events);
   }
 
 

--- a/packages/ecs/tsconfig.json
+++ b/packages/ecs/tsconfig.json
@@ -5,7 +5,6 @@
     "outDir": "dist",
     "module": "commonjs"
   },
-  "lib": ["es2015", "es5", "ScriptHost", "dom"],
   "include": ["src"],
   "exclude": ["**/*.spec.ts", "**/__mocks__/**/*"]
 }

--- a/packages/ecs/tsconfig.json
+++ b/packages/ecs/tsconfig.json
@@ -1,9 +1,11 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "downlevelIteration": true,
     "outDir": "dist",
     "module": "commonjs"
   },
+  "lib": ["es2015", "es5", "ScriptHost", "dom"],
   "include": ["src"],
   "exclude": ["**/*.spec.ts", "**/__mocks__/**/*"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "strict": true,
-    "downlevelIteration": true,
     "target": "ES2018",
     "module": "ESNext",
     "esModuleInterop": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "strict": true,
+    "downlevelIteration": true,
     "target": "ES2018",
     "module": "ESNext",
     "esModuleInterop": true,


### PR DESCRIPTION
This commit implements the topic type and helper methods. Primarily
focusing on the `createTopic`, which creates a topic with helper methods
to push events, flush events, and read events.