### PR TITLE
[hrtimer-loop] Bugfix: Fix callback argument type

### DIFF
--- a/packages/hrtime-loop/src/index.ts
+++ b/packages/hrtime-loop/src/index.ts
@@ -11,7 +11,7 @@ const getHrTimeMs = () => {
 
 export function createHrtimeLoop(
   tickRate: number,
-  callback: (clock: { dt: number }) => void,
+  callback: (clock: Clock) => void,
 ) {
   const clock: Clock = { dt: 0, now: 0, tick: 0 }
 


### PR DESCRIPTION
Fixes callback argument type, so all fields are available, not just dt.

Fixes #156 