### PR TITLE
fix: add spawn op type to message producer getReliableMessages

### DIFF
--- a/packages/net/src/message_producer.ts
+++ b/packages/net/src/message_producer.ts
@@ -155,6 +155,9 @@ export function createMessageProducer(
             }
             break
           }
+          case WorldOpType.Spawn:
+            filteredOps.push(op)
+            break
           case WorldOpType.Destroy:
             filteredOps.push(op)
             break


### PR DESCRIPTION
Resolves an issue found here https://github.com/3mcd/javelin/issues/136 where entities cannot be spawned in the client after the initial message. 

I didn't add a test for this, because I'm not sure how to stub out the world object yet. 