### PR TITLE
fix: ensure dimensions match viewport

### DIFF
--- a/examples/interop/src/main.ts
+++ b/examples/interop/src/main.ts
@@ -28,8 +28,7 @@ scene.add(
 )
 
 function scale() {
-  const parent = canvas.parentElement!
-  const { width, height } = parent.getBoundingClientRect()
+  const { innerWidth: width, innerHeight: height } = window
   camera.aspect = width / height
   camera.updateProjectionMatrix()
   renderer.setSize(width, height)


### PR DESCRIPTION
When running the example locally, the the canvas was set to a height of 0. In order to ensure the canvas' dimensions match that of the viewport, this PR sources dims from the window rather than the body.

Before:
<img src="https://user-images.githubusercontent.com/40576412/146992085-5cbdead3-9bdc-4eb7-98ce-09db1c4ace6e.png" alt="before change" height="200" />
After:
<img src="https://user-images.githubusercontent.com/40576412/146992092-f140c164-425c-4ba2-9ad8-2a6dab4e5d11.png" alt="after change" height="200" />

Enjoying using Javelin btw! Thanks for making it

